### PR TITLE
Fix assertion error if tcp timeouts more than 1 second

### DIFF
--- a/libmemcached/connect.cc
+++ b/libmemcached/connect.cc
@@ -268,29 +268,31 @@ static void set_socket_options(memcached_server_st *server)
   }
 
 #ifdef HAVE_SNDTIMEO
-  if (server->root->snd_timeout)
+  if (server->root->snd_timeout > 0)
   {
     struct timeval waittime;
 
-    waittime.tv_sec= 0;
-    waittime.tv_usec= server->root->snd_timeout;
+    waittime.tv_sec= server->root->snd_timeout / 1000000;
+    waittime.tv_usec= server->root->snd_timeout % 1000000;
 
     int error= setsockopt(server->fd, SOL_SOCKET, SO_SNDTIMEO,
-                      &waittime, (socklen_t)sizeof(struct timeval));
+                          (char*)&waittime, (socklen_t)sizeof(struct timeval));
+    (void)error;
     assert(error == 0);
   }
 #endif
 
 #ifdef HAVE_RCVTIMEO
-  if (server->root->rcv_timeout)
+  if (server->root->rcv_timeout > 0)
   {
     struct timeval waittime;
 
-    waittime.tv_sec= 0;
-    waittime.tv_usec= server->root->rcv_timeout;
+    waittime.tv_sec= server->root->rcv_timeout / 1000000;
+    waittime.tv_usec= server->root->rcv_timeout % 1000000;
 
     int error= setsockopt(server->fd, SOL_SOCKET, SO_RCVTIMEO,
-                          &waittime, (socklen_t)sizeof(struct timeval));
+                          (char*)&waittime, (socklen_t)sizeof(struct timeval));
+    (void)(error);
     assert(error == 0);
   }
 #endif


### PR DESCRIPTION
Hello!

When I set tcp timeouts over 1 second, I get the following error:
```
libmemcached/connect.cc:258: void set_socket_options(memcached_server_st*): Assertion `error == 0' failed.
```

Details in upstream bug:
https://bugs.launchpad.net/libmemcached/+bug/1021819

With this backport from newer libmemcached version error disappears. May be rebase from latest libmemcached release will be better solution.
