### PR TITLE
Fix compile error with g++ -std=c++0x

### DIFF
--- a/clients/memflush.cc
+++ b/clients/memflush.cc
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 {
   options_parse(argc, argv);
 
-  if (opt_servers == false)
+  if (opt_servers == NULL)
   {
     char *temp;
 
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
       opt_servers= strdup(temp);
     }
 
-    if (opt_servers == false)
+    if (opt_servers == NULL)
     {
       std::cerr << "No Servers provided" << std::endl;
       exit(EXIT_FAILURE);


### PR DESCRIPTION
When I tried to built this on ALAMI2 with gcc-7.3.1-5.amzn2.0.2.x86_64, it failed as follows.

```
make -j3  all-am
make[1]: Entering directory `/home/ec2-user/aws-elasticache-cluster-client-libmemcached-1.0.18/BUILD'
  CXX      clients/memflush.o
In file included from ../libmemcached-1.0/memcached.h:113:0,
                 from ../clients/memflush.cc:21:
../libmemcached-1.0/server.h:118:1: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
 const bool has_memcached_server_ipaddress(const memcached_server_st *self);
 ^~~~~
../libmemcached-1.0/server.h:121:1: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
 const bool has_memcached_instance_ipaddress(const memcached_instance_st *self);
 ^~~~~
../clients/memflush.cc: In function ‘int main(int, char**)’:
../clients/memflush.cc:42:22: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
   if (opt_servers == false)
                      ^~~~~
../clients/memflush.cc:51:24: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
     if (opt_servers == false)
                        ^~~~~
make[1]: *** [clients/memflush.o] Error 1
make[1]: Leaving directory `/home/ec2-user/aws-elasticache-cluster-client-libmemcached-1.0.18/BUILD'
make: *** [all] Error 2
```

Then, I found opt_servers variable is a pointer for char type and realized it should NOT be compared with boolean.
I noticed in Makefile that -std=c++0x was specified and probably this could find the error.
