### PR TITLE
Fix a libmemcached autodiscovery bug when multiple nodes change ip addresses within the same polling interval

### DIFF
--- a/libmemcached-1.0/server.h
+++ b/libmemcached-1.0/server.h
@@ -112,13 +112,13 @@ LIBMEMCACHED_API
 const char *memcached_server_name(const memcached_instance_st * self);
 
 LIBMEMCACHED_API
-char *memcached_server_ipaddress(const memcached_instance_st *self);
+const char *memcached_server_ipaddress(const memcached_instance_st *self);
 
 LIBMEMCACHED_API
-const bool has_memcached_server_ipaddress(const memcached_server_st *self);
+bool has_memcached_server_ipaddress(const memcached_server_st *self);
 
 LIBMEMCACHED_API
-const bool has_memcached_instance_ipaddress(const memcached_instance_st *self);
+bool has_memcached_instance_ipaddress(const memcached_instance_st *self);
 
 LIBMEMCACHED_API
 void memcached_update_ipaddress(memcached_instance_st *self, const memcached_string_t ipaddress);

--- a/libmemcached/hosts.cc
+++ b/libmemcached/hosts.cc
@@ -809,7 +809,6 @@ memcached_return_t notify_server_list_update(memcached_st *ptr, memcached_server
   }
   else if(reresolve_count > 0)
   {
-    servers_to_reresolve = libmemcached_xrealloc(ptr, servers_to_reresolve, reresolve_count, memcached_instance_st*);
     reresolve_servers_in_client(servers_to_reresolve, reresolve_count);
   }
 

--- a/libmemcached/memory.h
+++ b/libmemcached/memory.h
@@ -87,9 +87,9 @@ static inline void *libmemcached_realloc(const memcached_st *self, void *mem, si
   }
 
 #ifdef __cplusplus
-    return std::realloc(mem, size);
+    return std::realloc(mem, nmemb * size);
 #else
-    return realloc(mem, size);
+    return realloc(mem, nmemb * size);
 #endif
 }
 #define libmemcached_xrealloc(__memcachd_st, __mem, __nelem, __type) ((__type *)libmemcached_realloc((__memcachd_st), (__mem), (__nelem), sizeof(__type)))

--- a/libmemcached/server.cc
+++ b/libmemcached/server.cc
@@ -262,13 +262,15 @@ in_port_t memcached_server_port(const memcached_instance_st * self)
   return self->port();
 }
 
-const char *memcached_server_ipaddress(const memcached_server_instance_st self)
+const char *memcached_server_ipaddress(const memcached_instance_st self)
 {
   WATCHPOINT_ASSERT(self);
-  if (not self)
-    return NULL;
-
-  return self->_ipaddress;
+  if (self)
+  {
+    return self->_ipaddress;
+  }
+  
+  return NULL;
 }
 
 const bool _string_is_not_blank(const char* str) {
@@ -284,7 +286,7 @@ const bool _string_is_not_blank(const char* str) {
   return false;
 }
 
-const bool has_memcached_server_ipaddress(const memcached_server_st *self)
+bool has_memcached_server_ipaddress(const memcached_server_st *self)
 {
   WATCHPOINT_ASSERT(self);
   if (not self)
@@ -293,7 +295,7 @@ const bool has_memcached_server_ipaddress(const memcached_server_st *self)
   return _string_is_not_blank(self->ipaddress);
 }
 
-const bool has_memcached_instance_ipaddress(const memcached_instance_st *self)
+bool has_memcached_instance_ipaddress(const memcached_instance_st *self)
 {
   WATCHPOINT_ASSERT(self);
   if (not self)

--- a/tests/libmemcached-1.0/dynamic_mode_test.cc
+++ b/tests/libmemcached-1.0/dynamic_mode_test.cc
@@ -32,7 +32,7 @@ using namespace libtest;
  *
  *   ./configure
  *   make
- *   ./tests/dynamic_mode_test
+ *   YATL_COLLECTION_TO_RUN=dynamic_mode_test make test-mem (or make gdb-mem)
  */
 
 static char* _get_addr_by_ifa_name_for_ipv(const char* ifa_name_str, bool ipv6)
@@ -271,6 +271,12 @@ test_return_t replace_node_test(memcached_st *ptr)
 
   rc= memcached_instance_push(memc, ptr->configserver, 1);
 
+  servers= memcached_server_list_append(servers, ptr->servers[0]._hostname, ptr->servers[0].port(), &rc);
+  servers= memcached_server_list_append(servers, ptr->servers[1]._hostname, ptr->servers[1].port(), &rc);
+  servers= memcached_server_list_append(servers, ptr->servers[2]._hostname, ptr->servers[2].port(), &rc);
+  servers= memcached_server_list_append(servers, ptr->servers[3]._hostname, ptr->servers[3].port(), &rc);
+  notify_server_list_update(memc, servers);
+
   if (rc != MEMCACHED_SUCCESS)
   {
     return TEST_FAILURE;
@@ -293,6 +299,9 @@ test_return_t replace_node_test(memcached_st *ptr)
     return TEST_SKIPPED;
   }
   servers= memcached_server_list_append_with_ipaddress(servers, "localhost", local_ip, ptr->servers[0].port(), &rc);
+  servers= memcached_server_list_append_with_ipaddress(servers, "localhost", local_ip, ptr->servers[1].port(), &rc);
+  servers= memcached_server_list_append_with_ipaddress(servers, "localhost", local_ip, ptr->servers[2].port(), &rc);
+  servers= memcached_server_list_append_with_ipaddress(servers, "localhost", local_ip, ptr->servers[3].port(), &rc);
   notify_server_list_update(memc, servers);
 
   rc= memcached_set(memc, key, strlen(key), value, strlen(value), (time_t)0, (uint32_t)0);
@@ -438,7 +447,7 @@ test_return_t polling_test(memcached_st *ptr)
 
 void get_world(libtest::Framework *world)
 {
-  world->servers().set_servers_to_run(2);
+  world->servers().set_servers_to_run(4);
   world->collections(collection);
 
   world->create((test_callback_create_fn*)world_create);

--- a/tests/libmemcached-1.0/mem_functions.cc
+++ b/tests/libmemcached-1.0/mem_functions.cc
@@ -471,7 +471,7 @@ test_return_t libmemcached_string_behavior_test(memcached_st *)
   {
     test_true(libmemcached_string_behavior(memcached_behavior_t(x)));
   }
-  test_compare(39, int(MEMCACHED_BEHAVIOR_MAX));
+  test_compare(40, int(MEMCACHED_BEHAVIOR_MAX));
 
   return TEST_SUCCESS;
 }


### PR DESCRIPTION
During testing for memcached I uncovered a bug in the php client. If multiple nodes change their IP address within one polling interval then the php client with throw a `realloc(): invalid next size` error. This CR fixes the issue and adds a test to catch any regressions.

It also fixes the `memcached_server_ipaddress` function so that the IP address can be outputted as part of the `getServerList` response.