### PR TITLE
Fixing issue #20 - USE_TLS isn't defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,10 @@ AS_IF([test "x$enable_tls" != "xno"], [
 
        AC_CHECK_HEADERS([openssl/crypto.h openssl/x509.h openssl/pem.h openssl/ssl.h openssl/err.h],[],[AC_MSG_ERROR([OpenSSL headers required])])
 
+AS_IF([test "x$enable_tls" != "xno"],
+           [USE_TLS="#define USE_TLS 1"],
+           [USE_TLS="#define USE_TLS 0"])
+AC_SUBST([USE_TLS])
 
 # Adding support for libtest
 m4_include([libtest/yatl.m4])

--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -61,11 +61,6 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
             fi
         ]
         )
-        AS_IF([test "x$enable_tls" != "xno"],
-           [USE_TLS="#define USE_TLS 1"],
-           [USE_TLS="#define USE_TLS 0"])
-        AC_SUBST([USE_TLS])
-
 
     # note that we #include <openssl/foo.h>, so the OpenSSL headers have to be in
     # an 'openssl' subdirectory


### PR DESCRIPTION
*Description of changes:*
Compiling the library with --disable-tls flag fails since USE_TLS isn't defined.
Fixed USE_TLS to be define also when --disable-tls flag is passed.

Closes issue #20.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
