### PR TITLE
TLS: Free SSL context in memcached_quit

### DIFF
--- a/libmemcached/quit.cc
+++ b/libmemcached/quit.cc
@@ -164,4 +164,9 @@ void memcached_quit(memcached_st *shell)
   }
 
   send_quit(memc);
+
+#if defined(USE_TLS) && USE_TLS
+  memcached_free_ssl_ctx(memc);
+#endif
+
 }


### PR DESCRIPTION
When persistent ID is being used the php_memc_destroy destructor function isn't being called when the PHP Memcached struct is getting out of scope, so the memcached_st with all of its allocated structs aren't being freed. Instead, the user can call quit() to close all server connections when persistent ID is used. Therefore, this PR changes quit to also free the SSL context that is being stored in the memcached_st when quit is being called, to free all of the connections related TLS context. 