### PR TITLE
 TLS: Fix memory leak if memcached_create_and_set_ssl_context is call…

### DIFF
--- a/libmemcached/tls.c
+++ b/libmemcached/tls.c
@@ -390,6 +390,10 @@ memc_ssl_context_error memcached_create_and_set_ssl_context(memcached_st *ptr, m
         goto error;
     }
 
+    if (ptr->ssl_ctx) {
+        // TLS context already set, free it before we set the new context
+        _memcached_free_ssl_ctx(ptr, ptr->ssl_ctx);
+    }
     ptr->ssl_ctx = ssl_ctx;
 
     return MEMCACHED_SSL_CTX_SUCCESS;


### PR DESCRIPTION
When using the client with a persistent list (as we support in https://github.com/awslabs/aws-elasticache-cluster-client-memcached-for-php), if `createAndSetTLSContext` is invoked with an existing `memcached_st` object already configured with a TLS context, the pointer to the previous TLS context would have been overwritten, causing a memory leakage. This issue has been resolved by freeing the existing context before establishing a new one.